### PR TITLE
Added support for terraform.workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,28 @@ mock "aws_vpcs" "selected" {
 }
 ```
 
+### Terraform Workspace
 
+If you want to use the terraform workspace feature in terraspec you need to first configure which workspace value to use. You can do this in a spec global element `terraspec`:
+
+__default.tfspec__
+```hcl
+# define which workspace you want to test
+terraspec {
+    workspace = "development"
+}
+
+# use the workspace value in your test assertions or anywhere else
+assert "aws_vpc" "test_vpc" {
+    tags = {
+        "env": terraspec.workspace
+    }
+}
+```
+
+The stated workspace value will also be injected into the terraform configuration that is tested.
+
+See also [examples/workspace](examples/workspace).
 
 ### Run 
 

--- a/examples/workspace/main.tf
+++ b/examples/workspace/main.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block  = "192.168.0.0/16"
+  tags = {
+    workspace = terraform.workspace
+  }
+}

--- a/examples/workspace/spec/default/test.tfspec
+++ b/examples/workspace/spec/default/test.tfspec
@@ -1,0 +1,9 @@
+terraspec {
+  workspace = "somevalue"
+}
+
+assert "aws_vpc" "test" {
+  tags = {
+    workspace = terraspec.workspace
+  }
+}

--- a/lib/spec.go
+++ b/lib/spec.go
@@ -27,6 +27,12 @@ type Spec struct {
 	Refutes          []*Assert
 	Mocks            []*Mock
 	DataSourceReader *MockDataSourceReader
+	Terraspec        *TerraspecConfig 
+}
+
+// Terraspec contains a global element for a spec with common configuration similar to terraform hcl element.
+type TerraspecConfig struct {
+	Workspace string
 }
 
 // Assert struct contains the definition of an assertion
@@ -250,6 +256,9 @@ func ReadSpec(filename string, schemas *terraform.Schemas) (*Spec, tfdiags.Diagn
 
 // ParseSpec parses the spec contained in the []byte parameter and returns the resulting Spec or a Diagnostics if error occured in the process
 func ParseSpec(spec []byte, filename string, schemas *terraform.Schemas) (*Spec, hcl.Diagnostics) {
+	type terraspec struct {
+		Body hcl.Body       `hcl:",remain"`
+	}
 	type assert struct {
 		Type      string         `hcl:"type,label"`
 		Name      string         `hcl:"name,label"`
@@ -266,11 +275,15 @@ func ParseSpec(spec []byte, filename string, schemas *terraform.Schemas) (*Spec,
 		Refutes []*assert `hcl:"refute,block"`
 		Mocks   []*mock   `hcl:"mock,block"`
 		// Modules   []*Module   `hcl:"module,block"`
+		Terraspec *terraspec `hcl:"terraspec,block"`
 	}
 
 	var r root
 	parsed := &Spec{}
 	file, diags := hclparse.NewParser().ParseHCL(spec, filename)
+	ctx := &hcl.EvalContext{
+		Variables: make(map[string]cty.Value),
+	}
 
 	if diags.HasErrors() {
 		return nil, diags
@@ -279,9 +292,19 @@ func ParseSpec(spec []byte, filename string, schemas *terraform.Schemas) (*Spec,
 	if diags.HasErrors() {
 		return nil, diags
 	}
+	
+	if r.Terraspec != nil && r.Terraspec.Body != nil {
+		terraspecConfig, diags := decodeTerraspecConfig(&r.Terraspec.Body, ctx)
+		if diags.HasErrors() {
+			return nil, diags
+		}
+		parsed.Terraspec = terraspecConfig
+	} else {
+		parsed.Terraspec = &TerraspecConfig{}
+	}	
 
 	for _, assert := range r.Asserts {
-		val, diags := decodeBody(&assert.Config, assert.Type, schemas)
+		val, diags := decodeBody(&assert.Config, assert.Type, schemas, ctx)
 		if diags.HasErrors() {
 			return nil, diags
 		}
@@ -289,14 +312,14 @@ func ParseSpec(spec []byte, filename string, schemas *terraform.Schemas) (*Spec,
 	}
 
 	for _, assert := range r.Refutes {
-		val, diags := decodeBody(&assert.Config, assert.Type, schemas)
+		val, diags := decodeBody(&assert.Config, assert.Type, schemas, ctx)
 		if diags.HasErrors() {
 			return nil, diags
 		}
 		parsed.Refutes = append(parsed.Refutes, &Assert{Name: assert.Name, Type: assert.Type, Value: val})
 	}
 	for _, mock := range r.Mocks {
-		query, mocked, diags := decodeMockBody(mock.Config, mock.Type, schemas)
+		query, mocked, diags := decodeMockBody(mock.Config, mock.Type, schemas, ctx)
 		if diags.HasErrors() {
 			return nil, diags
 		}
@@ -310,7 +333,33 @@ func ParseSpec(spec []byte, filename string, schemas *terraform.Schemas) (*Spec,
 	return parsed, diags
 }
 
-func decodeBody(body *hcl.Body, bodyType string, schemas *terraform.Schemas) (cty.Value, hcl.Diagnostics) {
+func decodeTerraspecConfig(body *hcl.Body, ctx *hcl.EvalContext) (*TerraspecConfig, hcl.Diagnostics) {
+	spec := hcldec.ObjectSpec{
+		"workspace": &hcldec.AttrSpec{
+			Name:     "workspace",
+			Type:     cty.String,
+			Required: false,
+		},
+	}
+
+	val, diags := hcldec.Decode(*body, spec, nil)
+	if diags.HasErrors() {
+		return nil, diags
+	}
+
+	workspaceName := ""
+	if !val.IsNull() {
+		workspace := val.GetAttr("workspace")
+		ctx.Variables["terraspec"] = val
+		workspaceName = workspace.AsString()
+	}
+
+	return &TerraspecConfig{
+		Workspace: workspaceName,
+	}, nil
+}
+
+func decodeBody(body *hcl.Body, bodyType string, schemas *terraform.Schemas, ctx *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	rawType := resourceType(bodyType)
 	provName := strings.Split(rawType, "_")[0]
 	var val cty.Value
@@ -326,22 +375,22 @@ func decodeBody(body *hcl.Body, bodyType string, schemas *terraform.Schemas) (ct
 		partialSchema, _ = schema.SchemaForResourceType(addrs.ManagedResourceMode, rawType)
 	}
 
-	val, diags := hcldec.Decode(*body, partialSchema.DecoderSpec(), nil)
+	val, diags := hcldec.Decode(*body, partialSchema.DecoderSpec(), ctx)
 	return val, diags
 }
 
-func decodeMockBody(body hcl.Body, bodyType string, schemas *terraform.Schemas) (query, mock cty.Value, diags hcl.Diagnostics) {
+func decodeMockBody(body hcl.Body, bodyType string, schemas *terraform.Schemas, ctx *hcl.EvalContext) (query, mock cty.Value, diags hcl.Diagnostics) {
 	var codedMock hcl.Body
 	provName := strings.Split(bodyType, "_")[0]
 	schema := LookupProviderSchema(schemas, provName)
 	partialSchema, _ := schema.SchemaForResourceType(addrs.DataResourceMode, bodyType)
 
-	query, codedMock, diags = hcldec.PartialDecode(body, partialSchema.DecoderSpec(), nil)
+	query, codedMock, diags = hcldec.PartialDecode(body, partialSchema.DecoderSpec(), ctx)
 	if diags.HasErrors() {
 		return
 	}
 	mockedSchema := toMockSchema(partialSchema)
-	mock, moreDiags := hcldec.Decode(codedMock, mockedSchema.DecoderSpec(), nil)
+	mock, moreDiags := hcldec.Decode(codedMock, mockedSchema.DecoderSpec(), ctx)
 	diags = append(diags, moreDiags...)
 	if diags.HasErrors() {
 		return

--- a/lib/terraform.go
+++ b/lib/terraform.go
@@ -16,7 +16,7 @@ import (
 
 // NewContext creates a new terraform.Context able to compute configs in the context of terraspec
 // It returns the built Context or a Diagnostics if error occured
-func NewContext(dir, varFile string, resolver *ProviderResolver, tsCtx *Context) (*terraform.Context, tfdiags.Diagnostics) {
+func NewContext(dir, varFile string, resolver *ProviderResolver, tsCtx *Context, workspace string) (*terraform.Context, tfdiags.Diagnostics) {
 	absDir, err := filepath.Abs(dir)
 	diags := make(tfdiags.Diagnostics, 0)
 	if err != nil {
@@ -64,6 +64,9 @@ func NewContext(dir, varFile string, resolver *ProviderResolver, tsCtx *Context)
 		Providers:    providers,
 		Provisioners: ProvisionersFactory(),
 		Variables:    variables,
+		Meta: &terraform.ContextMeta{
+			Env: workspace,
+		},
 	}
 
 	return terraform.NewContext(opts)

--- a/lib/testdata/scenario_workspace.tfspec
+++ b/lib/testdata/scenario_workspace.tfspec
@@ -1,0 +1,22 @@
+terraspec {
+    workspace = "development"
+}
+
+assert "ressource_type" "name" {
+    property = terraspec.workspace
+    inner {
+        inner_prop = terraspec.workspace
+    }
+}
+
+refute "output" "name" {
+    value = terraspec.workspace
+}
+
+mock "data_type" "name"{
+    query = 0
+    return {
+        id = 12345
+        name = terraspec.workspace
+    }
+}

--- a/main.go
+++ b/main.go
@@ -185,14 +185,22 @@ func PrepareTestSuite(dir string, tc *testCase, tsCtx *terraspec.Context) (*terr
 		return nil, nil, ctxDiags
 	}
 
-	tfCtx, diags := terraspec.NewContext(dir, tc.variableFile, providerResolver, tsCtx) // Setting a different folder works to parse configuration but not the modules :/
+	// first we create a context to retrieve schemas for the providers, we need them to parse the spec file
+	tfCtxSchemas, diags := terraspec.NewContext(dir, tc.variableFile, providerResolver, tsCtx, "default") 
 	ctxDiags = ctxDiags.Append(diags)
 	if ctxDiags.HasErrors() {
 		return nil, nil, ctxDiags
 	}
 
 	// Parse specs may return mocked data source result
-	spec, diags := terraspec.ReadSpec(tc.specFile, tfCtx.Schemas())
+	spec, diags := terraspec.ReadSpec(tc.specFile, tfCtxSchemas.Schemas())
+	ctxDiags = ctxDiags.Append(diags)
+	if ctxDiags.HasErrors() {
+		return nil, nil, ctxDiags
+	}
+
+	// this is the actual tf context we use for testing
+	tfCtx, diags := terraspec.NewContext(dir, tc.variableFile, providerResolver, tsCtx, spec.Terraspec.Workspace) // Setting a different folder works to parse configuration but not the modules :/
 	ctxDiags = ctxDiags.Append(diags)
 	if ctxDiags.HasErrors() {
 		return nil, nil, ctxDiags


### PR DESCRIPTION
Hi,

I have implemented support for terraform workspaces. See the docs in the README.md for how it works.

I performed a slight renaming compared to #5. As terraform has its global `terraform` hcl element, I introduced a `terraspec`hcl block for terraspec. You can use it to configure e.g. the workspace. Perhaps there will be further attributes down the road that should live there.
